### PR TITLE
Add: if condition to check leftover being 0

### DIFF
--- a/contracts/cw-quadratic-funding/src/contract.rs
+++ b/contracts/cw-quadratic-funding/src/contract.rs
@@ -238,13 +238,15 @@ pub fn execute_trigger_distribution(
         }));
     }
 
-    let leftover_msg: CosmosMsg = CosmosMsg::Bank(BankMsg::Send {
-        to_address: config.leftover_addr,
-        amount: vec![coin(leftover, config.budget.denom)],
-    });
-
-    msgs.push(leftover_msg);
-
+    if leftover != 0 {
+        let leftover_msg: CosmosMsg = CosmosMsg::Bank(BankMsg::Send {
+            to_address: config.leftover_addr,
+            amount: vec![coin(leftover, config.budget.denom)],
+        });
+    
+        msgs.push(leftover_msg);
+    }
+    
     Ok(Response::new()
         .add_messages(msgs)
         .add_attribute("action", "trigger_distribution"))


### PR DESCRIPTION
In the trigger_distribution() function, if leftover is 0, executing the function returns ```Error: Query failed with (6): rpc error: code = Unknown desc = failed to execute message; message index: 0: dispatch: submessages: : invalid coins [cosmos/cosmos-sdk@v0.47.6/x/bank/types/msgs.go:50] With gas wanted: '100000000' and gas used: '180393' : unknown request``` An if condition checking the case leftover being 0 solves this error.